### PR TITLE
refactor: remove dead config and streamline dtsi files

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,25 @@ Keymap bindings look like `&plv PLV_TL`, `&plv PLV_X3`, etc. Include:
 #include <dt-bindings/zmk/hid-io/plover_hid.h>
 ```
 
-Steno mode is toggled via F17 / Ctrl+F17 (`steno_on` / `steno_off`); numpad signaling uses F18 / Ctrl+F18.
+Steno mode is toggled via F17 / Ctrl+F17 (`steno_on` / `steno_off`); numpad signaling uses F18 / Ctrl+F18. Layer-tap behaviors that use `*_s_num` wrappers emit F18 on hold/toggle so host apps can detect numpad mode.
 
-**Plover aliases:** `PLV_X3` and `PLV_X4` map to different HID bit indices than the old fork, but existing Plover aliases (`+-` ← `X3`, `^-` ← `X4`) continue to work. Details in **`docs/vanilla-migration-plan.md`** (Plover HID section).
+---
+
+## Config layout
+
+| File | Role |
+|---|---|
+| `dacman56.keymap` | Layer indices, conditional layers, key bindings |
+| `adaptive.dtsi` | urob `&ak_*` adaptive-key behaviors |
+| `behaviors.dtsi` | Hold-taps, tap dances, Plover `plv`, global `&sl` timeout |
+| `macros.dtsi` | Text/steno macros + F17/F18 signaling helpers (`to_s`, `mo_s_num`, …) |
+| `combos.dtsi` | 18 combos on default layers (+ numpad layers for Tab/Esc) |
+| `dacman56.conf` | Kconfig (HID, adaptive timing, BT/debounce tuning) |
+| `west.yml` | ZMK + module manifest |
+
+Include order in the keymap matters: `combos` → `behaviors` → `macros` → `adaptive`.
+
+--- `PLV_X3` and `PLV_X4` map to different HID bit indices than the old fork, but existing Plover aliases (`+-` ← `X3`, `^-` ← `X4`) continue to work. Details in **`docs/vanilla-migration-plan.md`** (Plover HID section).
 
 ---
 

--- a/config/behaviors.dtsi
+++ b/config/behaviors.dtsi
@@ -1,3 +1,4 @@
+/* Global sticky-layer timeout (applies to all &sl bindings). */
 &sl {
 	release-after-ms = <1500>;
 };
@@ -6,143 +7,114 @@
 #define idle_time_homerow_short 70
 
 / { behaviors {
-	// Hold-tap for F-keys
+	/* ── Mod / layer hold-taps ─────────────────────────────────────────── */
+
 	fn: fn_mod {
 		compatible = "zmk,behavior-hold-tap";
 		tapping-term-ms = <250>;
 		flavor = "balanced";
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		#binding-cells = <2>;
 		bindings = <&kp>, <&kp>;
 	};
-	
-	// Hold-tap for Upper F-keys
+
 	fm: high_fn_mod {
 		compatible = "zmk,behavior-hold-tap";
 		tapping-term-ms = <580>;
 		flavor = "balanced";
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		#binding-cells = <2>;
 		bindings = <&kp>, <&kp>;
 	};
 
-	// Hold-tap for layer-space with retro-tap
 	lts: layer_tap_sfn {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
-		flavor = "hold-preferred";		// hold behavior when tapping-term-ms expired or another key is pressed
-            	require-prior-idle-ms = <idle_time_homerow>;
+		flavor = "hold-preferred";
+		require-prior-idle-ms = <idle_time_homerow>;
 		tapping-term-ms = <500>;
 		bindings = <&mo>, <&kp>;
-		retro-tap;						// tap behavior triggered when releasing if no other key was pressed
+		retro-tap;
 	};
 
-	// Hold-tap for layer-space with retro-tap
 	lts_tp: layer_tap_sfn_tp {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
-		flavor = "tap-preferred";		// hold behavior when tapping-term-ms expired or another key is pressed
-            	require-prior-idle-ms = <idle_time_homerow>;
+		flavor = "tap-preferred";
+		require-prior-idle-ms = <idle_time_homerow>;
 		tapping-term-ms = <250>;
 		bindings = <&mo>, <&kp>;
-		retro-tap;						// tap behavior triggered when releasing if no other key was pressed
+		retro-tap;
 	};
-	
-	// Hold-tap for ctlr/esc
+
 	cesc: hold_tap_ctrl_esc {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		tapping-term-ms = <240>;
-		flavor = "balanced";		// hold behavior when tapping-term-ms expired or another key is pressed
+		flavor = "balanced";
 		bindings = <&kp>, <&kp>;
 	};
-	
-	
+
+	/* ── Homerow mods (tapping-term / idle tuning) ───────────────────────── */
+
 	hmf: homerow_mods_fast {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <170>;
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&kp>, <&kp>;
 	};
-	
+
 	hm: homerow_mods {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <175>;
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&kp>, <&kp>;
 	};
-	
+
 	hms: homerow_mod_slow {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <180>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&kp>, <&kp>;
 	};
-	
-	
-	// For that almost-zpecial finger
+
 	hmms: homerow_mod_mid_slow {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <225>;
-            	require-prior-idle-ms = <idle_time_homerow_short>;
+		require-prior-idle-ms = <idle_time_homerow_short>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";		// hold behavior when tapping-term-ms has expired. tap behavior when another key is pressed
+		flavor = "balanced";
 		bindings = <&kp>, <&kp>;
 	};
 
-	// For that zpecial finger
 	hmss: homerow_mod_sup_slow {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <249>;
-            	require-prior-idle-ms = <idle_time_homerow>;
+		require-prior-idle-ms = <idle_time_homerow>;
 		quick-tap-ms = <0>;
-		flavor = "tap-preferred";		// hold behavior when tapping-term-ms has expired. tap behavior when another key is pressed
+		flavor = "tap-preferred";
 		bindings = <&kp>, <&kp>;
 	};
-		
-	sq: sticky_q {
-		compatible = "zmk,behavior-sticky-key";
-		quick-release;
-		#binding-cells = <1>;
-		release-after-ms = <1500>;
-		bindings = <&kp>;
-	};
-	
-	k_or_lay: key_or_layer {
-		compatible = "zmk,behavior-hold-tap";
-		#binding-cells = <2>;
-		tapping-term-ms = <156>;
-		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
-		bindings = <&kp>, <&tog>;
-	};
-		
-	lay_or_lay: layer_or_layer {
-		compatible = "zmk,behavior-hold-tap";
-		#binding-cells = <2>;
-		tapping-term-ms = <156>;
-		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
-		bindings = <&mo>, <&tog>;
-	};
+
+	/* ── Numpad F18 signal wrappers (see macros.dtsi to_s_num / mo_s_num) ─ */
 
 	lay_or_lay_s_num: layer_or_layer_with_num_signal {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
 		tapping-term-ms = <136>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&mo_s_num>, <&tog_s_num>;
 	};
 
@@ -151,7 +123,7 @@
 		#binding-cells = <2>;
 		tapping-term-ms = <136>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&mo_s_num>, <&kp>;
 	};
 
@@ -160,7 +132,7 @@
 		#binding-cells = <2>;
 		tapping-term-ms = <186>;
 		quick-tap-ms = <0>;
-		flavor = "tap-preferred";			// hold behavior when tapping-term-ms has expired. tap behavior when another key is pressed
+		flavor = "tap-preferred";
 		bindings = <&mo_s_num>, <&kp>;
 	};
 
@@ -169,66 +141,53 @@
 		#binding-cells = <2>;
 		tapping-term-ms = <156>;
 		quick-tap-ms = <0>;
-		flavor = "balanced";			// hold behavior when tapping-term-ms has expired or another key is pressed and released
+		flavor = "balanced";
 		bindings = <&to_s_num>, <&kp>;
 	};
 
 	tl_s: tap_or_layer_signal {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
-		flavor = "hold-preferred";		// hold behavior when tapping-term-ms expired or another key is pressed
-            	require-prior-idle-ms = <idle_time_homerow>;
+		flavor = "hold-preferred";
+		require-prior-idle-ms = <idle_time_homerow>;
 		tapping-term-ms = <180>;
 		bindings = <&kp>, <&tog_s_num>;
 	};
 
-	hm_m_cspfn: homerow_mod_cspfn {
-		compatible = "zmk,behavior-hold-tap";
-		#binding-cells = <2>;
-		tapping-term-ms = <186>;
-		quick-tap-ms = <0>;
-		flavor = "balanced";
-		bindings = <&m_c_spfn>, <&kp>;
-	};
-
 	tog_on: toggle_layer_on_only {
-            compatible = "zmk,behavior-toggle-layer";
-            #binding-cells = <1>;
-            display-name = "Toggle Layer On";
-            toggle-mode = "on";
-        };
+		compatible = "zmk,behavior-toggle-layer";
+		#binding-cells = <1>;
+		display-name = "Toggle Layer On";
+		toggle-mode = "on";
+	};
 
-	tog_off: toggle_layer_off_only {
-            compatible = "zmk,behavior-toggle-layer";
-            #binding-cells = <1>;
-            display-name = "Toggle Layer Off";
-            toggle-mode = "off";
-        };
+	/* ── Tap dances ────────────────────────────────────────────────────── */
 
-        td_plus_sum: tap_dance_plus_sum {
-            compatible = "zmk,behavior-tap-dance";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp KP_PLUS>, <&m_sum>;
+	td_plus_sum: tap_dance_plus_sum {
+		compatible = "zmk,behavior-tap-dance";
+		#binding-cells = <0>;
+		tapping-term-ms = <200>;
+		bindings = <&kp KP_PLUS>, <&m_sum>;
 	};
-		
-        td_emails: tap_dance_emails {
-            compatible = "zmk,behavior-tap-dance";
-            #binding-cells = <0>;
-            tapping-term-ms = <420>;
-            bindings = <&m_email_w>, <&m_email_g>, <&m_email_w_old>, <&m_email_ph>;
+
+	td_emails: tap_dance_emails {
+		compatible = "zmk,behavior-tap-dance";
+		#binding-cells = <0>;
+		tapping-term-ms = <420>;
+		bindings = <&m_email_w>, <&m_email_g>, <&m_email_w_old>, <&m_email_ph>;
 	};
-		
-        td_names: tap_dance_namess {
-            compatible = "zmk,behavior-tap-dance";
-            #binding-cells = <0>;
-            tapping-term-ms = <420>;
-            bindings = <&m_phuerta>, <&m_ph>, <&m_pihy>;
+
+	td_names: tap_dance_names {
+		compatible = "zmk,behavior-tap-dance";
+		#binding-cells = <0>;
+		tapping-term-ms = <420>;
+		bindings = <&m_phuerta>, <&m_ph>, <&m_pihy>;
 	};
+
+	/* ── Plover HID ────────────────────────────────────────────────────── */
 
 	plv: plover_hid {
 		compatible = "zmk,behavior-plover-hid";
 		#binding-cells = <1>;
 	};
-
 }; };

--- a/config/combos.dtsi
+++ b/config/combos.dtsi
@@ -4,140 +4,139 @@
 #define COMB_LAY_ALL DEFAULT_HD DEFAULT_HD_2
 #define COMB_LAY_NUM NUM_HD_ULTRA NUM_HD_STENO_MODS
 
-
 / { combos {
 	compatible = "zmk,combos";
-	
+
 	combo_bootloader {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <32 47 63>;				// Última de abajo, el 5, y shift derecho
+		key-positions = <32 47 63>;
 		bindings = <&bootloader>;
 	};
-	
+
 	combo_TAB_L {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL COMB_LAY_NUM>;
-		key-positions = <28 40>;				// I y K
+		key-positions = <28 40>;
 		bindings = <&kp TAB>;
 	};
-	
+
 	combo_ESC_L {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL COMB_LAY_NUM>;
-		key-positions = <29 41>;				// U y X
+		key-positions = <29 41>;
 		bindings = <&kp ESC>;
 	};
-	
+
 	combo_EXCL {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <13 25>;				// ' y A
+		key-positions = <13 25>;
 		bindings = <&kp EXCL>;
 	};
-	
+
 	combo_INV_EXCL {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <49 13 25>;				// \, ' y A
+		key-positions = <49 13 25>;
 		bindings = <&kp RA(N1)>;
 	};
-	
+
 	combo_AT {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <14 26>;				// , y O
+		key-positions = <14 26>;
 		bindings = <&kp AT>;
 	};
-	
+
 	combo_HASH {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <15 27>;				// . y E
+		key-positions = <15 27>;
 		bindings = <&kp HASH>;
 	};
-	
+
 	combo_DLLR {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <16 28>;				// P y I
+		key-positions = <16 28>;
 		bindings = <&kp DLLR>;
 	};
-	
+
 	combo_PRCNT {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <17 29>;				// Y y U
+		key-positions = <17 29>;
 		bindings = <&kp PRCNT>;
 	};
-	
+
 	combo_CARET {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <18 30>;				// F y D
+		key-positions = <18 30>;
 		bindings = <&kp CARET>;
 	};
-	
+
 	combo_AMPS {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <19 31>;				// G y H
+		key-positions = <19 31>;
 		bindings = <&kp AMPERSAND>;
 	};
-	
+
 	combo_STAR {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <20 32>;				// L y T
+		key-positions = <20 32>;
 		bindings = <&kp STAR>;
 	};
-	
+
 	combo_LPAR {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <21 33>;				// R y N
+		key-positions = <21 33>;
 		bindings = <&kp LPAR>;
 	};
-	
+
 	combo_RPAR {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <22 34>;				// C y S
+		key-positions = <22 34>;
 		bindings = <&kp RPAR>;
 	};
-	
+
 	combo_ESC_R {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <30 42>;				// U y X
+		key-positions = <30 42>;
 		bindings = <&kp ESC>;
 	};
-	
+
 	combo_TAB_R {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <31 43>;				// H y M
+		key-positions = <31 43>;
 		bindings = <&kp TAB>;
 	};
-	
+
 	combo_PIPE2 {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <38 48>;				// Q y `
+		key-positions = <38 48>;
 		bindings = <&kp PIPE2>;
 	};
-	
+
 	combo_PIPE {
 		timeout-ms = <COMB_MS>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <39 49>;				// \ y J
+		key-positions = <39 49>;
 		bindings = <&kp PIPE>;
 	};
-	
+
 	combo_HD_SEMI {
 		timeout-ms = <COMB_MS_FST>;
 		layers = <COMB_LAY_ALL>;
-		key-positions = <25 37>;				// A y ;
+		key-positions = <25 37>;
 		bindings = <&kp LS(Z)>;
 	};
 }; };

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -1,7 +1,6 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/hid-io/plover_hid.h>
 

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -1,26 +1,23 @@
-// ─── Macro timing parameters ──────────────────────────────────────────────────
-#define MACRO_WAIT_DEFAULT        2    // ZMK_MACRO_ wait-ms default
-#define MACRO_TAP_DEFAULT        10    // ZMK_MACRO_ tap-ms default
-
-#define MACRO_WAIT_MIN            0    // minimum meaningful delay; use where 0 was a placeholder
-#define MACRO_WAIT_CHORD         40    // modifier-press macros needing settle time
-#define MACRO_WAIT_PAUSE          7    // mid-macro pause, gap between key and layer switch
-
-#define MACRO_WAIT_ALT_LONG      50    // m_9_16*: initial LALT settle
-#define MACRO_WAIT_ALT_SHORT     30    // m_9_16*: after LALT, before keys
-#define MACRO_WAIT_LAS           15    // m_las_n2/n3/n7: LALT → shifted digit gap
-// ──────────────────────────────────────────────────────────────────────────────
+#define MACRO_WAIT_DEFAULT        2
+#define MACRO_TAP_DEFAULT        10
+#define MACRO_WAIT_MIN            0
+#define MACRO_WAIT_CHORD         40
+#define MACRO_WAIT_PAUSE          7
+#define MACRO_WAIT_ALT_LONG      50
+#define MACRO_WAIT_ALT_SHORT     30
+#define MACRO_WAIT_LAS           15
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \
-			compatible = "zmk,behavior-macro"; \
-			#binding-cells = <0>; \
-			wait-ms = <MACRO_WAIT_DEFAULT>; \
-			tap-ms = <MACRO_TAP_DEFAULT>; \
-			__VA_ARGS__ \
-		};
+		compatible = "zmk,behavior-macro"; \
+		#binding-cells = <0>; \
+		wait-ms = <MACRO_WAIT_DEFAULT>; \
+		tap-ms = <MACRO_TAP_DEFAULT>; \
+		__VA_ARGS__ \
+	};
 
 / { behaviors {
+	/* Hold-tap wrappers that invoke a macro on hold */
 	hms_m_lsrs: lsrs_m_macro {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
@@ -33,8 +30,8 @@
 	ZMK_MACRO_(m_ls_rs,
 		wait-ms = <MACRO_WAIT_CHORD>;
 		bindings = <&macro_press &kp LSHFT>,
-				<&macro_tap &kp RSHFT>,
-				<&macro_release &kp LSHFT>;
+			<&macro_tap &kp RSHFT>,
+			<&macro_release &kp LSHFT>;
 	)
 
 	hms_m_KP_N00: KP_N00_m_macro {
@@ -61,95 +58,20 @@
 
 	ZMK_MACRO_(m_N88,
 		bindings = <&macro_press &kp LSHFT>,
-				<&macro_tap &kp N8 &kp N8>,
-				<&macro_release &kp LSHFT>;
+			<&macro_tap &kp N8 &kp N8>,
+			<&macro_release &kp LSHFT>;
 	)
 
-	ZMK_MACRO_(m_eq_sum,
-		bindings = <&kp RBKT &kp S &kp M &kp E &kp MINUS>;
-	)
-
+	/* Numpad / Excel helpers */
 	ZMK_MACRO_(m_sum,
 		bindings = <&kp S &kp M &kp E &kp MINUS>;
 	)
 
-	ZMK_MACRO_(m_9_16,
-		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
-				<&kp LALT>,
-				<&macro_wait_time MACRO_WAIT_ALT_SHORT>,
-				<&kp Q &kp J &kp SEMI &kp KP_N9 &kp TAB &kp KP_N1 &kp KP_N6 &kp ENTER &kp ESC>;
-	)
-
-	ZMK_MACRO_(m_9_16_steno,
-		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
-				<&kp LALT>,
-				<&macro_wait_time MACRO_WAIT_ALT_SHORT>,
-				<&kp Q &kp J &kp SEMI &kp LS(N1) &kp TAB &kp LS(N3) &kp LS(N6) &kp ENTER &kp ESC>;
-	)
-
-	ZMK_MACRO_(m_email_w,
-		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>,
-				<&kp LS(I)>,
-				<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI>,
-				<&kp W &kp C &kp COMMA &kp B &kp J &kp C>,
-				<&kp I &kp V &kp COMMA &kp E>;
-	)
-
-	ZMK_MACRO_(m_email_g,
-		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J &kp DOT>,
-				<&kp LS(I)>,
-				<&kp W &kp E &kp J &kp L &kp C>,
-				<&kp I &kp V &kp COMMA &kp E>;
-	)
-
-	ZMK_MACRO_(m_email_w_old,
-		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>,
-				<&kp LS(I)>,
-				<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI &kp J>,
-				<&kp F &kp FSLH &kp L &kp S &kp COMMA &kp A &kp S>,
-				<&kp I &kp V &kp COMMA &kp E>;
-	)
-
-	ZMK_MACRO_(m_email_ph,
-		bindings = <&kp G &kp SEMI>,
-				<&kp LS(I)>,
-				<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI>,
-				<&kp W &kp C &kp COMMA &kp B &kp J &kp C>,
-				<&kp I &kp V &kp COMMA &kp E>;
-	)
-
-	ZMK_MACRO_(m_phuerta,
-		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>;
-	)
-
-	ZMK_MACRO_(m_ph,
-		bindings = <&kp LS(G) &kp K &kp F &kp A &kp COMMA>,
-				<&kp SPACE>,
-				<&kp LS(SEMI) &kp M &kp K &kp A &kp GRAVE &kp J>;
-	)
-
-	ZMK_MACRO_(m_pihy,
-		bindings = <&kp LS(G) &kp K &kp F &kp A &kp COMMA>,
-				<&kp SPACE>,
-				<&kp LS(L) &kp I>,
-				<&kp SPACE>,
-				<&kp LS(SEMI) &kp M &kp K &kp A &kp GRAVE &kp J>,
-				<&kp SPACE>,
-				<&kp LS(DOT) &kp M &kp E &kp SEMI &kp J>;
-	)
-
 	ZMK_MACRO_(m_excel_go_to,
 		bindings = <&kp RC(W)>,
-				<&macro_press &mo DEFAULT_HD_2>,
-				<&macro_pause_for_release>,
-				<&macro_release &mo DEFAULT_HD_2>;
-	)
-
-	ZMK_MACRO_(m_c_spfn,
-		wait-ms = <MACRO_WAIT_CHORD>;
-		bindings = <&macro_press &mo SPFN_HD &kp RCTRL>,
-					<&macro_pause_for_release>,
-				<&macro_release &mo SPFN_HD &kp RCTRL>;
+			<&macro_press &mo DEFAULT_HD_2>,
+			<&macro_pause_for_release>,
+			<&macro_release &mo DEFAULT_HD_2>;
 	)
 
 	ZMK_MACRO_(m_paste_transp,
@@ -157,37 +79,31 @@
 		bindings = <&kp RC(LA(FSLH)) &kp LA(FSLH) &kp K &kp ENTER>;
 	)
 
-	ZMK_MACRO_(m_equity,
-		wait-ms = <MACRO_WAIT_CHORD>;
-		bindings = <&kp SPACE &kp LS(K)>,
-				<&macro_wait_time MACRO_WAIT_PAUSE>,
-				<&kp O &kp M &kp L &kp GRAVE &kp DOT>;
-	)
-
 	ZMK_MACRO_(m_calc,
 		bindings = <&macro_press &kp RGUI &kp RSHFT>,
-				<&macro_tap &kp N3>,
-				<&macro_release &kp RGUI &kp RSHFT>;
+			<&macro_tap &kp N3>,
+			<&macro_release &kp RGUI &kp RSHFT>;
 	)
 
 	ZMK_MACRO_(m_las_n2,
 		bindings = <&kp LALT>,
-				<&macro_wait_time MACRO_WAIT_LAS>,
-				<&kp LS(N2)>;
+			<&macro_wait_time MACRO_WAIT_LAS>,
+			<&kp LS(N2)>;
 	)
 
 	ZMK_MACRO_(m_las_n3,
 		bindings = <&kp LALT>,
-				<&macro_wait_time MACRO_WAIT_LAS>,
-				<&kp LS(N3)>;
+			<&macro_wait_time MACRO_WAIT_LAS>,
+			<&kp LS(N3)>;
 	)
 
 	ZMK_MACRO_(m_las_n7,
 		bindings = <&kp LALT>,
-				<&macro_wait_time MACRO_WAIT_LAS>,
-				<&kp LS(N7)>;
+			<&macro_wait_time MACRO_WAIT_LAS>,
+			<&kp LS(N7)>;
 	)
 
+	/* Layer + F17/F18 signaling */
 	ZMK_MACRO_(m_to_steno,
 		bindings = <&to STENO &kp steno_on>;
 	)
@@ -204,26 +120,84 @@
 		bindings = <&to DEFAULT_HD &kp steno_off &kp numpad_off>;
 	)
 
-	ZMK_MACRO_(m_plo_look,
-		bindings = <&macro_press &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_U &plv PLV_PR>,
-				<&macro_release &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_U &plv PLV_PR>;
-	)
-
-	ZMK_MACRO_(m_plo_add,
-		bindings = <&macro_press &plv PLV_TL &plv PLV_KL &plv PLV_U &plv PLV_PR &plv PLV_TR>,
-				<&macro_release &plv PLV_TL &plv PLV_KL &plv PLV_U &plv PLV_PR &plv PLV_TR>;
-	)
-
+	/* Steno word macros (Plover HID press/release) */
 	ZMK_MACRO_(m_pren,
-		bindings = <&macro_press &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>,
-				<&macro_release &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>;
+		bindings = <&macro_press &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>,
+			<&macro_release &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>;
 	)
 
 	ZMK_MACRO_(m_pren_s,
-		bindings = <&macro_press &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>,
-				<&macro_release &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>;
+		bindings = <&macro_press &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>,
+			<&macro_release &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>;
 	)
 
+	/* Email / name tap-dance targets */
+	ZMK_MACRO_(m_email_w,
+		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>,
+			<&kp LS(I)>,
+			<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI>,
+			<&kp W &kp C &kp COMMA &kp B &kp J &kp C>,
+			<&kp I &kp V &kp COMMA &kp E>;
+	)
+
+	ZMK_MACRO_(m_email_g,
+		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J &kp DOT>,
+			<&kp LS(I)>,
+			<&kp W &kp E &kp J &kp L &kp C>,
+			<&kp I &kp V &kp COMMA &kp E>;
+	)
+
+	ZMK_MACRO_(m_email_w_old,
+		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>,
+			<&kp LS(I)>,
+			<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI &kp J>,
+			<&kp F &kp FSLH &kp L &kp S &kp COMMA &kp A &kp S>,
+			<&kp I &kp V &kp COMMA &kp E>;
+	)
+
+	ZMK_MACRO_(m_email_ph,
+		bindings = <&kp G &kp SEMI>,
+			<&kp LS(I)>,
+			<&kp T &kp J &kp S &kp J &kp GRAVE &kp V &kp SEMI>,
+			<&kp W &kp C &kp COMMA &kp B &kp J &kp C>,
+			<&kp I &kp V &kp COMMA &kp E>;
+	)
+
+	ZMK_MACRO_(m_phuerta,
+		bindings = <&kp G &kp SEMI &kp M &kp K &kp A &kp GRAVE &kp J>;
+	)
+
+	ZMK_MACRO_(m_ph,
+		bindings = <&kp LS(G) &kp K &kp F &kp A &kp COMMA>,
+			<&kp SPACE>,
+			<&kp LS(SEMI) &kp M &kp K &kp A &kp GRAVE &kp J>;
+	)
+
+	ZMK_MACRO_(m_pihy,
+		bindings = <&kp LS(G) &kp K &kp F &kp A &kp COMMA>,
+			<&kp SPACE>,
+			<&kp LS(L) &kp I>,
+			<&kp SPACE>,
+			<&kp LS(SEMI) &kp M &kp K &kp A &kp GRAVE &kp J>,
+			<&kp SPACE>,
+			<&kp LS(DOT) &kp M &kp E &kp SEMI &kp J>;
+	)
+
+	ZMK_MACRO_(m_9_16,
+		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
+			<&kp LALT>,
+			<&macro_wait_time MACRO_WAIT_ALT_SHORT>,
+			<&kp Q &kp J &kp SEMI &kp KP_N9 &kp TAB &kp KP_N1 &kp KP_N6 &kp ENTER &kp ESC>;
+	)
+
+	ZMK_MACRO_(m_9_16_steno,
+		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
+			<&kp LALT>,
+			<&macro_wait_time MACRO_WAIT_ALT_SHORT>,
+			<&kp Q &kp J &kp SEMI &kp LS(N1) &kp TAB &kp LS(N3) &kp LS(N6) &kp ENTER &kp ESC>;
+	)
+
+	/* Parametric layer + signal macros (F17/F18) */
 	to_s: to_s {
 		compatible = "zmk,behavior-macro-two-param";
 		wait-ms = <MACRO_WAIT_PAUSE>;
@@ -243,17 +217,6 @@
 		bindings = <&macro_tap &kp numpad_on>
 			, <&macro_param_1to1>
 			, <&macro_tap &to MACRO_PLACEHOLDER>;
-	};
-
-	tog_s: tog_s {
-		compatible = "zmk,behavior-macro-two-param";
-		wait-ms = <MACRO_WAIT_PAUSE>;
-		tap-ms = <MACRO_WAIT_MIN>;
-		#binding-cells = <2>;
-		bindings = <&macro_param_2to1>
-			, <&macro_tap &kp MACRO_PLACEHOLDER>
-			, <&macro_param_1to1>
-			, <&macro_tap &tog MACRO_PLACEHOLDER>;
 	};
 
 	tog_s_num: tog_s_num {

--- a/config/west.yml
+++ b/config/west.yml
@@ -57,7 +57,6 @@ manifest:
     - name: zmk-keyboard-dacman56
       remote: ph
       revision: main
-    # Phase 4 — Plover HID:
     - name: zmk-hid-io-plover-hid
       remote: petercpark
       revision: main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Streamlines the config after the vanilla migration — no keymap binding changes.

### Removed dead code (~120 lines)
- **Macros:** `m_eq_sum`, `m_equity`, `m_plo_look`, `m_plo_add`, `m_c_spfn`, `tog_s`
- **Behaviors:** `sq`, `k_or_lay`, `lay_or_lay`, `hm_m_cspfn`, `tog_off`
- Unused `#include <dt-bindings/zmk/ext_power.h>`

### Reorganized
- **`behaviors.dtsi`** — grouped sections, consistent tabs, documented global `&sl` override
- **`macros.dtsi`** — grouped by purpose (helpers, steno, email, signaling)
- **`combos.dtsi`** — uniform formatting, removed stale inline comments

### Docs
- README: config file map, include order, F17/F18 signaling
- `west.yml`: drop obsolete Phase 4 comment

### Not changed (intentionally)
- Func layer duplication (FUNC_HD vs FUNC_MACR) — larger refactor
- LCNUM 13-key row — matches historical dacman56 matrix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cc0c446-6e24-4fb0-9b5a-c6f28bc8822a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cc0c446-6e24-4fb0-9b5a-c6f28bc8822a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

