### PR TITLE
docs: update branch names for main and adaptive-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ZMK user config for the [dacman56](https://github.com/phuertay/zmk-keyboard-dacman56) split keyboard (nice!nano v1).
 
-The **`vanilla`** branch builds against upstream **[zmkfirmware/zmk](https://github.com/zmkfirmware/zmk)** with external modules for adaptive keys and Plover HID. The **`Adaptive`** branch still uses the legacy **`phuertay/zmk`** fork until hardware validation is complete.
+The default **`main`** branch builds against upstream **[zmkfirmware/zmk](https://github.com/zmkfirmware/zmk)** with external modules for adaptive keys and Plover HID. **`adaptive-legacy`** keeps the old **`phuertay/zmk`** fork snapshot for reference.
 
 ---
 
-## Stack (`vanilla` branch)
+## Stack (`main` branch)
 
 | Component | Source |
 |---|---|
@@ -186,10 +186,10 @@ west build -s zmk/app -b nice_nano@1//zmk -d build/left -- -DSHIELD=dacman56_lef
 
 | Branch | Purpose |
 |---|---|
-| **`vanilla`** | Upstream ZMK + modules; migration target (CI green) |
-| **`Adaptive`** | Legacy fork-based production until merged from `vanilla` |
+| **`main`** | Default — upstream ZMK + modules (CI green) |
+| **`adaptive-legacy`** | Archived fork-based config (pre-migration snapshot) |
 
-Merge **`vanilla` → `Adaptive`** only after on-keyboard validation (adaptives, numpad, steno, combos).
+Validate on hardware from **`main`** before deleting **`adaptive-legacy`** (adaptives, numpad, steno, combos).
 
 ---
 

--- a/docs/vanilla-migration-plan.md
+++ b/docs/vanilla-migration-plan.md
@@ -1,6 +1,6 @@
 # Vanilla ZMK migration
 
-**Branch:** `vanilla` · **Production until sign-off:** `Adaptive` (legacy `phuertay/zmk` fork)
+**Default branch:** `main` (renamed from `vanilla`) · **Archive:** `adaptive-legacy` (renamed from `Adaptive`, legacy `phuertay/zmk` fork)
 
 This config builds on **[zmkfirmware/zmk](https://github.com/zmkfirmware/zmk)** with **[urob/zmk-adaptive-key](https://github.com/urob/zmk-adaptive-key)** and **[petercpark/zmk-hid-io-plover-hid](https://github.com/petercpark/zmk-hid-io-plover-hid)**. User-facing docs live in **`README.md`**.
 
@@ -11,7 +11,7 @@ This config builds on **[zmkfirmware/zmk](https://github.com/zmkfirmware/zmk)** 
 | Implementation | Done ([#17](https://github.com/phuertay/zmk-config/pull/17)) |
 | CI | Green — `dacman56_left`, `dacman56_right`, `settings_reset` |
 | Hardware validation | Pending |
-| Merge to `Adaptive` | After sign-off ([#16](https://github.com/phuertay/zmk-config/pull/16)) |
+| Default branch | `main` (2026-06) — planning PR [#16](https://github.com/phuertay/zmk-config/pull/16) superseded by [#17](https://github.com/phuertay/zmk-config/pull/17)–[#22](https://github.com/phuertay/zmk-config/pull/22) |
 
 ## Current layer stack (10 layers)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates documentation after the GitHub branch reorganization:

- Default branch is now **`main`** (formerly `vanilla`)
- Legacy fork snapshot is **`adaptive-legacy`** (formerly `Adaptive`)
- Migration plan status reflects that PR #16 was superseded by #17–#22

No config or build changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

