### PR TITLE
fix: restore m_pren steno outlines for parenthesis macros

### DIFF
--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -115,13 +115,13 @@
 
 	/* Steno word macros (Plover HID press/release) */
 	ZMK_MACRO_(m_pren,
-		bindings = <&macro_press &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>,
-			<&macro_release &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>;
+		bindings = <&macro_press &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>,
+			<&macro_release &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR>;
 	)
 
 	ZMK_MACRO_(m_pren_s,
-		bindings = <&macro_press &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>,
-			<&macro_release &plv PLV_PL &plv PLV_HL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>;
+		bindings = <&macro_press &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>,
+			<&macro_release &plv PLV_PL &plv PLV_RL &plv PLV_E &plv PLV_PR &plv PLV_BR &plv PLV_ST>;
 	)
 
 	/* Email / name tap-dance targets */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The steno-layer thumb macros `m_pren` and `m_pren_s` (parenthesis outlines) stopped working after commit `d0f8c7c`.

During the macro cleanup, `PLV_HL` from the deleted `m_plo_look` macro was accidentally merged into both `m_pren` and `m_pren_s`, changing the steno chord from:

- `PL · RL · E · PR · BR` (± `ST`)

to the incorrect:

- `PL · **HL** · RL · E · PR · BR` (± `ST`)

## Fix

Restore the pre-regression key sequences from `adaptive-legacy` / pre-`d0f8c7c` history, keeping the migrated `&plv` bindings.

## Test plan

- [ ] Flash firmware from CI build
- [ ] On STENO layer, tap left thumb (`m_pren`) — outputs expected open paren
- [ ] On STENO layer, tap right thumb (`m_pren_s`) — outputs expected close paren
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

