### PR TITLE
fix: steno numpad tap uses LS(N*) tri-layer, not KP_N*

### DIFF
--- a/config/behaviors.dtsi
+++ b/config/behaviors.dtsi
@@ -118,6 +118,16 @@
 		bindings = <&mo_s_num>, <&tog_s_num>;
 	};
 
+	/* STENO: tap must latch numpad like mo hold (tog_s_num alone skips tri-layer) */
+	lay_or_lay_steno_num: layer_or_layer_steno_num_signal {
+		compatible = "zmk,behavior-hold-tap";
+		#binding-cells = <2>;
+		tapping-term-ms = <136>;
+		quick-tap-ms = <0>;
+		flavor = "balanced";
+		bindings = <&mo_s_num>, <&tog_s_steno_num>;
+	};
+
 	lt_s: layer_or_tap_signal {
 		compatible = "zmk,behavior-hold-tap";
 		#binding-cells = <2>;
@@ -151,7 +161,7 @@
 		flavor = "hold-preferred";
 		require-prior-idle-ms = <idle_time_homerow>;
 		tapping-term-ms = <180>;
-		bindings = <&kp>, <&tog_s_num>;
+		bindings = <&kp>, <&tog_s_steno_num>;
 	};
 
 	tog_on: toggle_layer_on_only {
@@ -159,6 +169,12 @@
 		#binding-cells = <1>;
 		display-name = "Toggle Layer On";
 		toggle-mode = "on";
+	};
+
+	tog_lock: toggle_layer_lock {
+		compatible = "zmk,behavior-toggle-layer";
+		#binding-cells = <1>;
+		locking;
 	};
 
 	/* ── Tap dances ────────────────────────────────────────────────────── */

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -66,7 +66,7 @@
 				&plv PLV_X4              &plv PLV_SL              &plv PLV_KL              &plv PLV_WL              &plv PLV_RL              &plv PLV_ST              &plv PLV_ST              &plv PLV_RR              &plv PLV_BR              &plv PLV_GR              &plv PLV_SR              &plv PLV_ZR
 				&tl_s LSHFT NUM_HD_ULTRA &hmms RCTRL RC(X)                               &m_pren                  &m_pren_s
 				&plv PLV_A             &plv PLV_O                                      &plv PLV_E              &plv PLV_U
-				&trans                 &trans                                          &trans                  &trans
+				&trans                 &trans                                          &lay_or_lay_steno_num NUM_HD_ULTRA NUM_HD_ULTRA &trans
 				&trans                 &trans                                          &m_from_steno           &trans
 			>;
 		};

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -84,6 +84,8 @@
 			>;
 		};
 
+		/* STENO+numpad: right cluster uses fm+LS(N*) tap (top-row digits), never KP_N*.
+		 * Requires STENO+NUM_HD_ULTRA → NUM_HD_STENO_MODS (tri-layer). */
 		num_hd_steno_mods {
 			bindings = <
 				&trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans                   &trans

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -222,6 +222,22 @@
 			, <&macro_tap &tog_on MACRO_PLACEHOLDER>;
 	};
 
+	/* Latch numpad via mo then locking toggle so STENO+NUM tri-layer stays active */
+	tog_s_steno_num: tog_s_steno_num {
+		compatible = "zmk,behavior-macro-one-param";
+		wait-ms = <MACRO_WAIT_MIN>;
+		tap-ms = <MACRO_WAIT_MIN>;
+		#binding-cells = <1>;
+		bindings = <&macro_tap &kp numpad_on>
+			, <&macro_param_1to1>
+			, <&macro_press &mo MACRO_PLACEHOLDER>
+			, <&macro_wait_time MACRO_WAIT_PAUSE>
+			, <&macro_param_1to1>
+			, <&macro_tap &tog_lock MACRO_PLACEHOLDER>
+			, <&macro_release &mo MACRO_PLACEHOLDER>
+			, <&macro_tap &kp numpad_off>;
+	};
+
 	mo_s_num: mo_s_num {
 		compatible = "zmk,behavior-macro-one-param";
 		wait-ms = <MACRO_WAIT_MIN>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On STENO, tap-toggle numpad (`lay_or_lay_s_num` / `tog_s_num`) could leave you on the full `NUM_HD_ULTRA` layer instead of the `NUM_HD_STENO_MODS` tri-layer. The right-hand number cluster then sends **`KP_N*`** (numpad HID) instead of **`LS(N*)`** (shifted top-row digits via `fm`).

Hold on `&lt_s NUM_HD_ULTRA N4` worked because `mo_s_num` reliably activates the tri-layer with the LS bindings.

## Fix

- **`tog_s_steno_num`** — tap macro: `mo` press → wait → locking `tog` → `mo` release (latches tri-layer like hold)
- **`lay_or_lay_steno_num`** — steno-only hold-tap: hold = `mo_s_num`, tap = `tog_s_steno_num`
- **Steno keymap** — inner thumb uses `lay_or_lay_steno_num`; `tl_s` tap uses `tog_s_steno_num`
- **Default `lay_or_lay_s_num` unchanged** — still uses `tog_s_num` + `KP_N*` (correct off-steno)

## Right cluster (unchanged bindings, now reliably reached)

| Tap output | Steno+numpad (`NUM_HD_STENO_MODS`) | Normal numpad (`NUM_HD_ULTRA`) |
|------------|-------------------------------------|--------------------------------|
| Right `fm` keys | `LS(N5)`, `LS(N0)`, `LS(N1)`, … | `KP_N7`, `KP_N8`, `KP_N9`, … |

## Test plan

- [ ] STENO → tap inner thumb numpad → right `fm` taps send top-row digits (`%`, `)`, …), not numpad keys
- [ ] STENO → hold `lt_s` N4 → same LS behavior
- [ ] DEFAULT_HD → tap `lay_or_lay_s_num` → still `KP_N*` on right (unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

