### PR TITLE
fix: latch numpad toggle for steno tri-layer LS right cluster

### DIFF
--- a/config/behaviors.dtsi
+++ b/config/behaviors.dtsi
@@ -161,6 +161,12 @@
 		toggle-mode = "on";
 	};
 
+	tog_lock: toggle_layer_lock {
+		compatible = "zmk,behavior-toggle-layer";
+		#binding-cells = <1>;
+		locking;
+	};
+
 	/* ── Tap dances ────────────────────────────────────────────────────── */
 
 	td_plus_sum: tap_dance_plus_sum {

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -66,7 +66,7 @@
 				&plv PLV_X4              &plv PLV_SL              &plv PLV_KL              &plv PLV_WL              &plv PLV_RL              &plv PLV_ST              &plv PLV_ST              &plv PLV_RR              &plv PLV_BR              &plv PLV_GR              &plv PLV_SR              &plv PLV_ZR
 				&tl_s LSHFT NUM_HD_ULTRA &hmms RCTRL RC(X)                               &m_pren                  &m_pren_s
 				&plv PLV_A             &plv PLV_O                                      &plv PLV_E              &plv PLV_U
-				&trans                 &trans                                          &trans                  &trans
+				&trans                 &trans                                          &lay_or_lay_s_num NUM_HD_ULTRA NUM_HD_ULTRA &trans
 				&trans                 &trans                                          &m_from_steno           &trans
 			>;
 		};

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -219,7 +219,12 @@
 		#binding-cells = <1>;
 		bindings = <&macro_tap &kp numpad_on>
 			, <&macro_param_1to1>
-			, <&macro_tap &tog_on MACRO_PLACEHOLDER>;
+			, <&macro_press &mo MACRO_PLACEHOLDER>
+			, <&macro_wait_time MACRO_WAIT_PAUSE>
+			, <&macro_param_1to1>
+			, <&macro_tap &tog_lock MACRO_PLACEHOLDER>
+			, <&macro_release &mo MACRO_PLACEHOLDER>
+			, <&macro_tap &kp numpad_off>;
 	};
 
 	mo_s_num: mo_s_num {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On STENO, tap-toggling numpad often skipped the conditional tri-layer (`NUM_HD_STENO_MODS`) and landed on full `NUM_HD_ULTRA` instead. The right-hand `fm` keys then sent **`KP_N*`** (numpad HID) rather than the **`LS(N*)`** top-row digits defined for steno+numpad.

Hold on `&lt_s NUM_HD_ULTRA N4` worked because `mo_s_num` reliably activates `STENO` + `NUM_HD_ULTRA` → `NUM_HD_STENO_MODS`.

The tri-layer keymap was already correct — no binding changes needed there:

| Row | Right cluster (`NUM_HD_STENO_MODS`) |
|-----|-------------------------------------|
| 2 | `fm F7 LS(N5)` `fm F8 LS(N0)` `fm F9 LS(N1)` `fm F12 N` |
| 3 | `fm F1 LS(N3)` `fm F2 LS(N7)` `fm F3 LS(N2)` |
| 4 | `fm F4 LS(N9)` `fm F5 LS(N4)` `fm F6 LS(N6)` |
| thumb | `fm F10 LS(N8)`, `kp LS(N8)` |

## Fix

Update the existing **`tog_s_num`** macro (no duplicate) to latch the layer the same way hold does:

1. `numpad_on`
2. `mo` press
3. brief wait
4. locking `tog`
5. `mo` release
6. `numpad_off`

Also bind **`lay_or_lay_s_num`** directly on the steno inner thumb (was `&trans` fallthrough to default).

Default-layer numpad tap still uses the same `tog_s_num`; off-steno you get `NUM_HD_ULTRA` with `KP_N*` as before.

## Test plan

- [ ] STENO → tap inner thumb numpad → right `fm` taps output `LS(N*)` digits (`%`, `)`, `!`, …)
- [ ] STENO → hold `lt_s` N4 → same
- [ ] STENO → tap again → numpad toggles off
- [ ] DEFAULT_HD → tap `lay_or_lay_s_num` → right cluster still `KP_N*`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

