### PR TITLE
fix: steno numpad keymap binding (keycodes only)

### DIFF
--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -66,7 +66,7 @@
 				&plv PLV_X4              &plv PLV_SL              &plv PLV_KL              &plv PLV_WL              &plv PLV_RL              &plv PLV_ST              &plv PLV_ST              &plv PLV_RR              &plv PLV_BR              &plv PLV_GR              &plv PLV_SR              &plv PLV_ZR
 				&tl_s LSHFT NUM_HD_ULTRA &hmms RCTRL RC(X)                               &m_pren                  &m_pren_s
 				&plv PLV_A             &plv PLV_O                                      &plv PLV_E              &plv PLV_U
-				&trans                 &trans                                          &trans                  &trans
+				&trans                 &trans                                          &lay_or_lay_s_num NUM_HD_ULTRA NUM_HD_ULTRA &trans
 				&trans                 &trans                                          &m_from_steno           &trans
 			>;
 		};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On STENO, tap-toggling numpad should activate the conditional tri-layer (`NUM_HD_STENO_MODS`) so the right-hand `fm` cluster sends **`LS(N*)`** top-row digits. Hold on `&lt_s NUM_HD_ULTRA N4` / `N7` already works via `mo_s_num`.

The tri-layer keymap bindings are already correct (unchanged vs `adaptive-legacy`):

| Row | Right cluster (`NUM_HD_STENO_MODS`) |
|-----|-------------------------------------|
| 2 | `fm F7 LS(N5)` `fm F8 LS(N0)` `fm F9 LS(N1)` `fm F12 N` |
| 3 | `fm F1 LS(N3)` `fm F2 LS(N7)` `fm F3 LS(N2)` |
| 4 | `fm F4 LS(N9)` `fm F5 LS(N4)` `fm F6 LS(N6)` |
| thumb | `fm F10 LS(N8)`, `kp LS(N8)` |

## Fix (keymap only)

Bind **`lay_or_lay_s_num`** explicitly on the steno inner thumb instead of `&trans`.

`&to STENO` deactivates `DEFAULT_HD`, so transparent keys on the steno layer do **not** fall through to the default thumb's `lay_or_lay_s_num`. The inner thumb was effectively unbound for numpad toggle while in steno.

**No changes** to `macros.dtsi`, `behaviors.dtsi`, or `tog_s_num`.

`NUM_HD_ULTRA` still uses `KP_N*` on the right for off-steno numpad tap.

## Replaces

Closes approach from #27 (macro latch / `tog_lock`) — keymap-only alternative.

## Test plan

- [ ] STENO → tap inner thumb numpad → right `fm` taps output `LS(N*)` digits (`%`, `)`, `!`, …)
- [ ] STENO → hold `lt_s` N4 / N7 → same
- [ ] STENO → tap again → numpad toggles off
- [ ] DEFAULT_HD → tap `lay_or_lay_s_num` → right cluster still `KP_N*`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

