### PR TITLE
fix: restore m_9_16 to left FUNC thumb (legacy layout)

### DIFF
--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -157,8 +157,8 @@
 				&kp C_AL_CONTACTS        &kp C_AL_MAIL            &kp C_AL_CCC             &kp C_AL_CAL             &kp C_AL_WWW             &td_names                &kp C_AC_STOP            &kp C_AL_CALC            &kp C_AC_FAVORITES       &kp LG(F13)              &kp C_AC_SEND            &kp C_AL_MY_COMPUTER
 				&kp C_BRI_DN             &kp C_BRI_UP                                     &kp C_AC_BACK            &kp C_AC_FORWARD
 				&kp C_AL_SELECT_TASK     &kp INS                                          &kp C_AC_HOME           &kp C_AC_BACK
-				&trans                   &trans                                          &m_9_16                 &m_to_steno
-				&to DEFAULT_HD           &kp INS                                          &trans                   &tog SPFN_HD
+				&m_9_16                 &kp INS                                          &trans                   &tog SPFN_HD
+				&to DEFAULT_HD           &m_to_steno                                      &trans                   &to DEFAULT_HD
 			>;
 		};
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

During the FUNC_HD + FUNC_MACR merge, `m_9_16` and `m_to_steno` were placed on the **right** thumb cluster. On `adaptive-legacy` they lived on the **left** (same keys as `&sl FUNC` / `&m_calc` on default).

## Fix

Restore `function_layer` thumb rows to match legacy `FUNC_MACR`:

| Row | Left outer | Left inner | Right inner | Right outer |
|-----|------------|------------|-------------|-------------|
| upper | `m_9_16` | `kp INS` | `trans` | `tog SPFN_HD` |
| lower | `to DEFAULT_HD` | `m_to_steno` | `trans` | `to DEFAULT_HD` |

**`FUNC_STENO_MODS`** unchanged — overlay already targets the same slots:

- `m_9_16_steno` → left outer (overrides `m_9_16`)
- `m_from_steno` → left inner lower row (overrides `m_to_steno`)

## Test plan

- [ ] Latch FUNC → left outer thumb fires `m_9_16`
- [ ] Latch FUNC → left inner lower thumb fires `m_to_steno`
- [ ] STENO + FUNC → left outer fires `m_9_16_steno`; lower left inner fires `m_from_steno`
- [ ] Right thumbs still: INS row above, SPFN toggle, to default
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

