### PR TITLE
fix: slow m_9_16 macro timing

### DIFF
--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -3,8 +3,9 @@
 #define MACRO_WAIT_MIN            0
 #define MACRO_WAIT_CHORD         40
 #define MACRO_WAIT_PAUSE          7
-#define MACRO_WAIT_ALT_LONG      50
-#define MACRO_WAIT_ALT_SHORT     30
+#define MACRO_WAIT_ALT_LONG      65
+#define MACRO_WAIT_ALT_SHORT     40
+#define MACRO_TAP_9_16           18
 #define MACRO_WAIT_LAS           15
 
 #define ZMK_MACRO_(name,...) \
@@ -177,6 +178,7 @@
 	)
 
 	ZMK_MACRO_(m_9_16,
+		tap-ms = <MACRO_TAP_9_16>;
 		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
 			<&kp LALT>,
 			<&macro_wait_time MACRO_WAIT_ALT_SHORT>,
@@ -184,6 +186,7 @@
 	)
 
 	ZMK_MACRO_(m_9_16_steno,
+		tap-ms = <MACRO_TAP_9_16>;
 		bindings = <&macro_wait_time MACRO_WAIT_ALT_LONG>,
 			<&kp LALT>,
 			<&macro_wait_time MACRO_WAIT_ALT_SHORT>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`m_9_16` runs too fast — the LALT chord and key sequence can outpace apps (especially Excel) before modifiers settle.

## Fix

Slow timing for **`m_9_16`** and **`m_9_16_steno`** only:

| Parameter | Before | After |
|---|---|---|
| Pre-LALT wait | 50 ms | 65 ms |
| Post-LALT wait | 30 ms | 40 ms |
| Per-key tap-ms | 10 ms (default) | 18 ms |

These constants are only used by the 9/16 macros.

## Related

Builds on #29 (FUNC thumb restore for `m_9_16`).

## Test plan

- [ ] FUNC → left outer `m_9_16` completes Excel go-to reliably
- [ ] STENO + FUNC → `m_9_16_steno` same
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

