### PR TITLE
fix: restore macro default wait/tap timings to 2/8

### DIFF
--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -1,5 +1,5 @@
-#define MACRO_WAIT_DEFAULT        1
-#define MACRO_TAP_DEFAULT         1
+#define MACRO_WAIT_DEFAULT        2
+#define MACRO_TAP_DEFAULT         8
 #define MACRO_WAIT_MIN            0
 #define MACRO_WAIT_CHORD         40
 #define MACRO_WAIT_PAUSE          7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restores the default macro timing values in `config/macros.dtsi` after the recent 1/1 speed-up caused email macros to drop characters over BLE.

## Changes

- `MACRO_WAIT_DEFAULT`: 1 → **2**
- `MACRO_TAP_DEFAULT`: 1 → **8**

These values apply to all macros using the `ZMK_MACRO_` wrapper, including the email/name tap-dance targets.

## Context

The 1/1 defaults were too aggressive for long typed sequences over Bluetooth. Restoring 2/8 brings back the prior balance between speed and reliability without going all the way to ZMK's stock 15/30 defaults.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dfa5905-208a-4623-8f6e-9ed2a2e5b573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dfa5905-208a-4623-8f6e-9ed2a2e5b573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

