### PR TITLE
Fix i ng race: ak_SPACE timing and drop L trigger

### DIFF
--- a/config/adaptive.dtsi
+++ b/config/adaptive.dtsi
@@ -199,11 +199,7 @@
 		compatible = "zmk,behavior-adaptive-key";
 		#binding-cells = <0>;
 		bindings = <&kp SPACE>;
-		akt_ldw_l {
-			trigger-keys = <L>;
-			max-prior-idle-ms = <MACRO_WAIT_SPACE_ROLL>;
-			bindings = <&m_space_delayed_roll>;
-		};
+		/* No akt_ldw_l — prior L alone is just i; delaying space there caused i ng */
 		akt_ldw_d {
 			trigger-keys = <D>;
 			max-prior-idle-ms = <MACRO_WAIT_SPACE_ROLL>;

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -7,10 +7,10 @@
 #define MACRO_WAIT_ALT_SHORT     40
 #define MACRO_TAP_9_16           18
 #define MACRO_WAIT_LAS           15
-#define MACRO_WAIT_SPACE_DELAY       25
-#define MACRO_WAIT_SPACE_DELAY_ROLL  40
-#define MACRO_WAIT_SPACE_PRIOR       80
-#define MACRO_WAIT_SPACE_ROLL        80
+#define MACRO_WAIT_SPACE_DELAY       50
+#define MACRO_WAIT_SPACE_DELAY_ROLL  65
+#define MACRO_WAIT_SPACE_PRIOR       120
+#define MACRO_WAIT_SPACE_ROLL        120
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -158,12 +158,13 @@ Left thumb `&hmss SPACE GRAVE` unchanged. Delays space during rolls so morphs ca
 
 | Trigger | Prior label | Roll | Delay |
 |---------|-------------|------|-------|
-| `akt_ldw_l` | `L` | `ldw` / `-ing` | 40 ms |
-| `akt_ldw_d` | `D` | `ldw` / `-ing` | 40 ms |
-| `akt_ew_e` | `E` | `ew` → `ng` | 40 ms |
-| `akt_after_w` | `W` | `ldw` or `ew` | 25 ms |
+| `akt_ldw_d` | `D` | `ldw` / `-ing` | 65 ms |
+| `akt_ew_e` | `E` | `ew` → `ng` | 65 ms |
+| `akt_after_w` | `W` | `ldw` or `ew` | 50 ms |
 
-Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (25), `MACRO_WAIT_SPACE_DELAY_ROLL` (40), `MACRO_WAIT_SPACE_PRIOR` / `MACRO_WAIT_SPACE_ROLL` (80).
+No trigger on prior `L` alone — that is just `i`; delaying space after `L` produced `i ng` when rolling `ldw` for `-ing`.
+
+Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (50), `MACRO_WAIT_SPACE_DELAY_ROLL` (65), `MACRO_WAIT_SPACE_PRIOR` / `MACRO_WAIT_SPACE_ROLL` (120).
 
 Space is always sent after the delay — never swallowed.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **`i ng`** when rolling **`ldw`** for `-ing`: space was firing after prior **`L`** (`i`) before **`D`**/**`W`** completed.

## Changes

- **Remove `akt_ldw_l`** — prior `L` alone is just `i`; delayed space there split `ldw` into `i` + `ng`
- **Bump delays** in `config/macros.dtsi`:
  - `MACRO_WAIT_SPACE_DELAY`: 25 → **50** ms (after `W`)
  - `MACRO_WAIT_SPACE_DELAY_ROLL`: 40 → **65** ms (`D` / `E` rolls)
  - `MACRO_WAIT_SPACE_PRIOR` / `MACRO_WAIT_SPACE_ROLL`: 80 → **120** ms

## `ak_SPACE` triggers (right thumb)

| Trigger | Prior | Roll | Delay |
|---------|-------|------|-------|
| `akt_ldw_d` | `D` | `ldw` | 65 ms |
| `akt_ew_e` | `E` | `ew` → `ng` | 65 ms |
| `akt_after_w` | `W` | `ldw` or `ew` | 50 ms |

## Test plan

- [ ] `L` `D` `W` → `ing` (not `i ng`)
- [ ] `E` `W` → `ng`
- [ ] Space after `-ing` / `ng` rolls feels right (not sluggish)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

