### PR TITLE
Fix i ng: akt_ldw_l timing on right-thumb ak_SPACE

### DIFF
--- a/config/adaptive.dtsi
+++ b/config/adaptive.dtsi
@@ -199,7 +199,12 @@
 		compatible = "zmk,behavior-adaptive-key";
 		#binding-cells = <0>;
 		bindings = <&kp SPACE>;
-		/* No akt_ldw_l — prior L alone is just i; delaying space there caused i ng */
+		/* Early space after L (thumb during ldw roll): long delay so D,W finish first */
+		akt_ldw_l {
+			trigger-keys = <L>;
+			max-prior-idle-ms = <MACRO_WAIT_SPACE_L_PRIOR>;
+			bindings = <&m_space_delayed_ldw_l>;
+		};
 		akt_ldw_d {
 			trigger-keys = <D>;
 			max-prior-idle-ms = <MACRO_WAIT_SPACE_ROLL>;

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -9,8 +9,10 @@
 #define MACRO_WAIT_LAS           15
 #define MACRO_WAIT_SPACE_DELAY       50
 #define MACRO_WAIT_SPACE_DELAY_ROLL  65
+#define MACRO_WAIT_SPACE_DELAY_LDW   90
 #define MACRO_WAIT_SPACE_PRIOR       120
 #define MACRO_WAIT_SPACE_ROLL        120
+#define MACRO_WAIT_SPACE_L_PRIOR      55
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \
@@ -112,6 +114,12 @@
 		wait-ms = <MACRO_WAIT_MIN>;
 		tap-ms = <MACRO_WAIT_MIN>;
 		bindings = <&macro_wait_time MACRO_WAIT_SPACE_DELAY_ROLL &kp SPACE>;
+	)
+
+	ZMK_MACRO_(m_space_delayed_ldw_l,
+		wait-ms = <MACRO_WAIT_MIN>;
+		tap-ms = <MACRO_WAIT_MIN>;
+		bindings = <&macro_wait_time MACRO_WAIT_SPACE_DELAY_LDW &kp SPACE>;
 	)
 
 	/* Layer + F17/F18 signaling */

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -150,6 +150,7 @@ Use **`ldw`** for the suffix. Example **`thing`**: type labels for `t` `h` `i` `
 | D | `&kp D` |
 | E | `&ak_E` |
 | W | `&ak_W` |
+| left thumb | `&hmss SPACE GRAVE` (unchanged) |
 | right thumb | `&ak_SPACE` |
 
 ## `ak_SPACE` (right thumb)
@@ -158,13 +159,14 @@ Left thumb `&hmss SPACE GRAVE` unchanged. Delays space during rolls so morphs ca
 
 | Trigger | Prior label | Roll | Delay |
 |---------|-------------|------|-------|
+| `akt_ldw_l` | `L` (within 55 ms) | early thumb during `ldw` | 90 ms |
 | `akt_ldw_d` | `D` | `ldw` / `-ing` | 65 ms |
 | `akt_ew_e` | `E` | `ew` → `ng` | 65 ms |
 | `akt_after_w` | `W` | `ldw` or `ew` | 50 ms |
 
-No trigger on prior `L` alone — that is just `i`; delaying space after `L` produced `i ng` when rolling `ldw` for `-ing`.
+`akt_ldw_l` only fires when space follows `L` within **55 ms** (roll start). Intentional `i` + space after a pause uses immediate space. The **90 ms** delay lets `D` and `W` finish first.
 
-Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (50), `MACRO_WAIT_SPACE_DELAY_ROLL` (65), `MACRO_WAIT_SPACE_PRIOR` / `MACRO_WAIT_SPACE_ROLL` (120).
+Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (50), `MACRO_WAIT_SPACE_DELAY_ROLL` (65), `MACRO_WAIT_SPACE_DELAY_LDW` (90), `MACRO_WAIT_SPACE_L_PRIOR` (55), prior windows (120).
 
 Space is always sent after the delay — never swallowed.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI and **`i ng`** on right-thumb `&ak_SPACE` only. Left thumb `&hmss SPACE GRAVE` unchanged.

## CI fix

Removed broken `hmss_ak` (`#binding-cells = <1>` on hold-tap requires 2). Branch squashed to a single commit with no left-thumb changes.

## Firmware

**`akt_ldw_l`** on right-thumb `&ak_SPACE`:
- Fires only if space follows `L` within **55 ms** (early roll-start thumb hit)
- **90 ms** delay before space — lets `D` and `W` finish first
- Intentional `i` + pause + space → immediate (prior idle > 55 ms)

## Test plan

- [ ] CI green
- [ ] `L` `D` `W` + right-thumb space → `ing ` (not `i ng`)
- [ ] `E` `W` → `ng`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

