### PR TITLE
Widen akt_ldw_l window; bump ldw delays for i ng

### DIFF
--- a/config/adaptive.dtsi
+++ b/config/adaptive.dtsi
@@ -199,10 +199,10 @@
 		compatible = "zmk,behavior-adaptive-key";
 		#binding-cells = <0>;
 		bindings = <&kp SPACE>;
-		/* Early space after L (thumb during ldw roll): long delay so D,W finish first */
+		/* Early space after L: wide prior window + long delay so D,W finish first */
 		akt_ldw_l {
 			trigger-keys = <L>;
-			max-prior-idle-ms = <MACRO_WAIT_SPACE_L_PRIOR>;
+			max-prior-idle-ms = <MACRO_WAIT_SPACE_ROLL>;
 			bindings = <&m_space_delayed_ldw_l>;
 		};
 		akt_ldw_d {
@@ -218,7 +218,7 @@
 		akt_after_w {
 			trigger-keys = <W>;
 			max-prior-idle-ms = <MACRO_WAIT_SPACE_PRIOR>;
-			bindings = <&m_space_delayed>;
+			bindings = <&m_space_delayed_roll>;
 		};
 	};
 

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -7,12 +7,12 @@
 #define MACRO_WAIT_ALT_SHORT     40
 #define MACRO_TAP_9_16           18
 #define MACRO_WAIT_LAS           15
-#define MACRO_WAIT_SPACE_DELAY       50
-#define MACRO_WAIT_SPACE_DELAY_ROLL  65
-#define MACRO_WAIT_SPACE_DELAY_LDW   90
-#define MACRO_WAIT_SPACE_PRIOR       120
-#define MACRO_WAIT_SPACE_ROLL        120
-#define MACRO_WAIT_SPACE_L_PRIOR      55
+#define MACRO_WAIT_SPACE_DELAY       65
+#define MACRO_WAIT_SPACE_DELAY_ROLL  80
+#define MACRO_WAIT_SPACE_DELAY_LDW   110
+#define MACRO_WAIT_SPACE_PRIOR       150
+#define MACRO_WAIT_SPACE_ROLL        150
+#define MACRO_WAIT_SPACE_L_PRIOR      65
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -7,12 +7,10 @@
 #define MACRO_WAIT_ALT_SHORT     40
 #define MACRO_TAP_9_16           18
 #define MACRO_WAIT_LAS           15
-#define MACRO_WAIT_SPACE_DELAY       65
-#define MACRO_WAIT_SPACE_DELAY_ROLL  80
-#define MACRO_WAIT_SPACE_DELAY_LDW   110
-#define MACRO_WAIT_SPACE_PRIOR       150
-#define MACRO_WAIT_SPACE_ROLL        150
-#define MACRO_WAIT_SPACE_L_PRIOR      65
+#define MACRO_WAIT_SPACE_DELAY_ROLL  100
+#define MACRO_WAIT_SPACE_DELAY_LDW   150
+#define MACRO_WAIT_SPACE_PRIOR       180
+#define MACRO_WAIT_SPACE_ROLL        180
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \
@@ -104,12 +102,6 @@
 	)
 
 	/* Term rolls — see docs/term-layout.md (ak_SPACE). */
-	ZMK_MACRO_(m_space_delayed,
-		wait-ms = <MACRO_WAIT_MIN>;
-		tap-ms = <MACRO_WAIT_MIN>;
-		bindings = <&macro_wait_time MACRO_WAIT_SPACE_DELAY &kp SPACE>;
-	)
-
 	ZMK_MACRO_(m_space_delayed_roll,
 		wait-ms = <MACRO_WAIT_MIN>;
 		tap-ms = <MACRO_WAIT_MIN>;

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -159,14 +159,14 @@ Left thumb `&hmss SPACE GRAVE` unchanged. Delays space during rolls so morphs ca
 
 | Trigger | Prior label | Roll | Delay |
 |---------|-------------|------|-------|
-| `akt_ldw_l` | `L` (within 65 ms) | early thumb during `ldw` | 110 ms |
-| `akt_ldw_d` | `D` | `ldw` / `-ing` | 80 ms |
-| `akt_ew_e` | `E` | `ew` → `ng` | 80 ms |
-| `akt_after_w` | `W` | `ldw` or `ew` | 65 ms |
+| `akt_ldw_l` | `L` (within 180 ms) | early thumb during `ldw` | 150 ms |
+| `akt_ldw_d` | `D` | `ldw` / `-ing` | 100 ms |
+| `akt_ew_e` | `E` | `ew` → `ng` | 100 ms |
+| `akt_after_w` | `W` | `ldw` or `ew` | 100 ms |
 
-`akt_ldw_l` only fires when space follows `L` within **65 ms** (roll start). Intentional `i` + space after a pause uses immediate space. The **110 ms** delay lets `D` and `W` finish first.
+`akt_ldw_l` fires when space follows `L` within **180 ms** (full roll window). The tight **65 ms** window missed slower rolls and caused immediate space → `i ng`. Intentional `i` + pause + space (>180 ms) stays immediate. The **150 ms** delay lets `D` and `W` finish first.
 
-Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (65), `MACRO_WAIT_SPACE_DELAY_ROLL` (80), `MACRO_WAIT_SPACE_DELAY_LDW` (110), `MACRO_WAIT_SPACE_L_PRIOR` (65), prior windows (150).
+Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY_ROLL` (100), `MACRO_WAIT_SPACE_DELAY_LDW` (150), prior windows (180).
 
 Space is always sent after the delay — never swallowed.
 

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -159,14 +159,14 @@ Left thumb `&hmss SPACE GRAVE` unchanged. Delays space during rolls so morphs ca
 
 | Trigger | Prior label | Roll | Delay |
 |---------|-------------|------|-------|
-| `akt_ldw_l` | `L` (within 55 ms) | early thumb during `ldw` | 90 ms |
-| `akt_ldw_d` | `D` | `ldw` / `-ing` | 65 ms |
-| `akt_ew_e` | `E` | `ew` → `ng` | 65 ms |
-| `akt_after_w` | `W` | `ldw` or `ew` | 50 ms |
+| `akt_ldw_l` | `L` (within 65 ms) | early thumb during `ldw` | 110 ms |
+| `akt_ldw_d` | `D` | `ldw` / `-ing` | 80 ms |
+| `akt_ew_e` | `E` | `ew` → `ng` | 80 ms |
+| `akt_after_w` | `W` | `ldw` or `ew` | 65 ms |
 
-`akt_ldw_l` only fires when space follows `L` within **55 ms** (roll start). Intentional `i` + space after a pause uses immediate space. The **90 ms** delay lets `D` and `W` finish first.
+`akt_ldw_l` only fires when space follows `L` within **65 ms** (roll start). Intentional `i` + space after a pause uses immediate space. The **110 ms** delay lets `D` and `W` finish first.
 
-Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (50), `MACRO_WAIT_SPACE_DELAY_ROLL` (65), `MACRO_WAIT_SPACE_DELAY_LDW` (90), `MACRO_WAIT_SPACE_L_PRIOR` (55), prior windows (120).
+Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY` (65), `MACRO_WAIT_SPACE_DELAY_ROLL` (80), `MACRO_WAIT_SPACE_DELAY_LDW` (110), `MACRO_WAIT_SPACE_L_PRIOR` (65), prior windows (150).
 
 Space is always sent after the delay — never swallowed.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent **`i ng`** when rolling **`ldw`** for `-ing`. The **65 ms** `akt_ldw_l` prior window was too tight — space 70–120 ms after `L` bypassed the trigger and fired immediately.

## Changes

| Setting | Was | Now |
|---------|-----|-----|
| `akt_ldw_l` prior window | 65 ms | **180 ms** (full roll window) |
| `MACRO_WAIT_SPACE_DELAY_LDW` | 110 ms | **150 ms** |
| Roll / after-`W` delay | 65–80 ms | **100 ms** |
| Prior windows | 150 ms | **180 ms** |

- `akt_after_w` now uses `m_space_delayed_roll` (same 100 ms as other roll ends)
- Removed unused `m_space_delayed`

Intentional `i` + pause + space (>180 ms after `L`) stays immediate.

## Test plan

- [ ] `L` `D` `W` + space → `ing ` (not `i ng`)
- [ ] `E` `W` → `ng`
- [ ] Space after `-ing` doesn't feel too sluggish
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

