### PR TITLE
Fix i ng: space_tui roll guard + longer ldw delays

### DIFF
--- a/config/adaptive.dtsi
+++ b/config/adaptive.dtsi
@@ -208,7 +208,7 @@
 		akt_ldw_d {
 			trigger-keys = <D>;
 			max-prior-idle-ms = <MACRO_WAIT_SPACE_ROLL>;
-			bindings = <&m_space_delayed_roll>;
+			bindings = <&m_space_delayed_ldw_l>;
 		};
 		akt_ew_e {
 			trigger-keys = <E>;
@@ -220,6 +220,15 @@
 			max-prior-idle-ms = <MACRO_WAIT_SPACE_PRIOR>;
 			bindings = <&m_space_delayed_roll>;
 		};
+	};
+
+	/* Suppress space tap while ldw roll keys still active; then ak_SPACE delays */
+	space_tui: space_tap_unless_interrupted {
+		compatible = "zmk,behavior-hold-tap";
+		#binding-cells = <0>;
+		flavor = "tap-unless-interrupted";
+		tapping-term-ms = <120>;
+		bindings = <&none>, <&ak_SPACE>;
 	};
 
 	ak_FSLH: ak_FSLH {

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -52,7 +52,7 @@
 				&cesc RCTRL ESC          &hms_m_a NAV_OVL 0       &ak_S                    &kp D                    &lt_s NUM_HD_ULTRA F     &hms RALT G              &hms RALT H              &kp J                    &kp K                    &kp L                    &ak_SEMI                 &kp SQT
 				&hms_m_lsrs LSHFT 0      &ak_Z                    &hms_m_x LALT 0          &hm_m_c LSHFT 0          &hmms RCTRL V            &kp B                    &kp N                    &hms_m_m RCTRL 0         &hmf RSHFT COMMA         &hmms LALT DOT           &ak_FSLH                 &hms RSHFT KP_NUM
 				&to_tap_s NUM_HD_ULTRA RBKT &hm H BSLH                                      &kp MINUS                &kp EQUAL
-				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &ak_SPACE
+				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui
 				&kp LALT               &hms RCTL DEL                                   &lay_or_lay_s_num NUM_HD_ULTRA NUM_HD_ULTRA &kp LCTL
 				&sl FUNC                &m_calc                                         &m_to_steno              &sl FUNC
 			>;
@@ -117,7 +117,7 @@
 				&cesc RCTRL ESC          &hms_m_a NAV_OVL 0       &ak_S                    &kp D                    &lt NUM_HD_ULTRA F       &hms RALT G              &hms RALT H              &kp J                    &kp K                    &kp L                    &ak_SEMI                 &kp SQT
 				&hms_m_lsrs LSHFT 0      &ak_Z                    &hms_m_x LALT 0          &hm_m_c LSHFT 0          &hmms RCTRL V            &kp B                    &kp N                    &hms_m_m RCTRL 0         &hmf RSHFT COMMA         &hmms LALT DOT           &ak_FSLH                 &hms RSHFT KP_NUM
 				&hm TILDE RBKT          &hm H BSLH                                      &kp MINUS                &kp EQUAL
-				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &ak_SPACE
+				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui
 				&kp LALT               &kp DEL                                         &tog NUM_HD_ULTRA       &kp LWIN
 				&sl FUNC                &kp C_AL_CALC                                   &kp C_AC_REFRESH        &sl FUNC
 			>;

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -7,10 +7,10 @@
 #define MACRO_WAIT_ALT_SHORT     40
 #define MACRO_TAP_9_16           18
 #define MACRO_WAIT_LAS           15
-#define MACRO_WAIT_SPACE_DELAY_ROLL  100
-#define MACRO_WAIT_SPACE_DELAY_LDW   150
-#define MACRO_WAIT_SPACE_PRIOR       180
-#define MACRO_WAIT_SPACE_ROLL        180
+#define MACRO_WAIT_SPACE_DELAY_ROLL  120
+#define MACRO_WAIT_SPACE_DELAY_LDW   220
+#define MACRO_WAIT_SPACE_PRIOR       220
+#define MACRO_WAIT_SPACE_ROLL        220
 
 #define ZMK_MACRO_(name,...) \
 	name: name { \

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -151,24 +151,26 @@ Use **`ldw`** for the suffix. Example **`thing`**: type labels for `t` `h` `i` `
 | E | `&ak_E` |
 | W | `&ak_W` |
 | left thumb | `&hmss SPACE GRAVE` (unchanged) |
-| right thumb | `&ak_SPACE` |
+| right thumb | `&space_tui` → `&ak_SPACE` |
 
 ## `ak_SPACE` (right thumb)
 
-Left thumb `&hmss SPACE GRAVE` unchanged. Delays space during rolls so morphs can finish. Triggers on the **label last pressed**:
+Right thumb uses **`&space_tui`**: `tap-unless-interrupted` with hold `&none` — if another key is pressed during the 120 ms tapping term (mid-roll), space is **not** sent. Clean tap after the roll reaches `&ak_SPACE` for adaptive delays.
+
+Left thumb `&hmss SPACE GRAVE` unchanged. Triggers on the **label last pressed**:
 
 | Trigger | Prior label | Roll | Delay |
 |---------|-------------|------|-------|
-| `akt_ldw_l` | `L` (within 180 ms) | early thumb during `ldw` | 150 ms |
-| `akt_ldw_d` | `D` | `ldw` / `-ing` | 100 ms |
-| `akt_ew_e` | `E` | `ew` → `ng` | 100 ms |
-| `akt_after_w` | `W` | `ldw` or `ew` | 100 ms |
+| `akt_ldw_l` | `L` (within 220 ms) | early thumb during `ldw` | 220 ms |
+| `akt_ldw_d` | `D` | `ldw` / `-ing` | 220 ms |
+| `akt_ew_e` | `E` | `ew` → `ng` | 120 ms |
+| `akt_after_w` | `W` | `ldw` or `ew` | 120 ms |
 
-`akt_ldw_l` fires when space follows `L` within **180 ms** (full roll window). The tight **65 ms** window missed slower rolls and caused immediate space → `i ng`. Intentional `i` + pause + space (>180 ms) stays immediate. The **150 ms** delay lets `D` and `W` finish first.
+`akt_ldw_l` / `akt_ldw_d` use the long **220 ms** delay so `D` and `W` can finish if space still gets through.
 
-Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY_ROLL` (100), `MACRO_WAIT_SPACE_DELAY_LDW` (150), prior windows (180).
+Tunables in `config/macros.dtsi`: `MACRO_WAIT_SPACE_DELAY_ROLL` (120), `MACRO_WAIT_SPACE_DELAY_LDW` (220), prior windows (220).
 
-Space is always sent after the delay — never swallowed.
+Mid-roll space taps are suppressed (`space_tui` hold `none`). Post-roll taps always send space after the adaptive delay.
 
 ## Morph summary
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes remaining **`i ng`** when rolling **`ldw`** for `-ing`. Delays alone helped but didn't cover slow rolls or thumb hits while `L`/`D`/`W` are still active.

## Changes

### `space_tui` (right thumb)
`tap-unless-interrupted` wrapper: hold `&none`, tap `&ak_SPACE`. If another key is pressed during the 120 ms tapping term (mid-roll), **no space is sent**. Clean tap after the roll still goes through `ak_SPACE`.

### Longer ldw delays (backup)
| Setting | Was | Now |
|---------|-----|-----|
| `MACRO_WAIT_SPACE_DELAY_LDW` | 150 ms | **220 ms** |
| `akt_ldw_d` macro | roll (100 ms) | **ldw (220 ms)** |
| Prior windows | 180 ms | **220 ms** |
| Roll delay | 100 ms | **120 ms** |

Left thumb unchanged.

## Test plan

- [ ] `L` `D` `W` + right-thumb space → `ing ` (not `i ng`)
- [ ] `E` `W` → `ng`
- [ ] Space after normal words still OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

