### PR TITLE
Fix space_tui hold-tap binding-cells for CI

### DIFF
--- a/config/adaptive.dtsi
+++ b/config/adaptive.dtsi
@@ -225,7 +225,7 @@
 	/* Suppress space tap while ldw roll keys still active; then ak_SPACE delays */
 	space_tui: space_tap_unless_interrupted {
 		compatible = "zmk,behavior-hold-tap";
-		#binding-cells = <0>;
+		#binding-cells = <2>;
 		flavor = "tap-unless-interrupted";
 		tapping-term-ms = <120>;
 		bindings = <&none>, <&ak_SPACE>;

--- a/config/dacman56.keymap
+++ b/config/dacman56.keymap
@@ -52,7 +52,7 @@
 				&cesc RCTRL ESC          &hms_m_a NAV_OVL 0       &ak_S                    &kp D                    &lt_s NUM_HD_ULTRA F     &hms RALT G              &hms RALT H              &kp J                    &kp K                    &kp L                    &ak_SEMI                 &kp SQT
 				&hms_m_lsrs LSHFT 0      &ak_Z                    &hms_m_x LALT 0          &hm_m_c LSHFT 0          &hmms RCTRL V            &kp B                    &kp N                    &hms_m_m RCTRL 0         &hmf RSHFT COMMA         &hmms LALT DOT           &ak_FSLH                 &hms RSHFT KP_NUM
 				&to_tap_s NUM_HD_ULTRA RBKT &hm H BSLH                                      &kp MINUS                &kp EQUAL
-				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui
+				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui 0 0
 				&kp LALT               &hms RCTL DEL                                   &lay_or_lay_s_num NUM_HD_ULTRA NUM_HD_ULTRA &kp LCTL
 				&sl FUNC                &m_calc                                         &m_to_steno              &sl FUNC
 			>;
@@ -117,7 +117,7 @@
 				&cesc RCTRL ESC          &hms_m_a NAV_OVL 0       &ak_S                    &kp D                    &lt NUM_HD_ULTRA F       &hms RALT G              &hms RALT H              &kp J                    &kp K                    &kp L                    &ak_SEMI                 &kp SQT
 				&hms_m_lsrs LSHFT 0      &ak_Z                    &hms_m_x LALT 0          &hm_m_c LSHFT 0          &hmms RCTRL V            &kp B                    &kp N                    &hms_m_m RCTRL 0         &hmf RSHFT COMMA         &hmms LALT DOT           &ak_FSLH                 &hms RSHFT KP_NUM
 				&hm TILDE RBKT          &hm H BSLH                                      &kp MINUS                &kp EQUAL
-				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui
+				&hmss SPACE GRAVE      &lts SPFN_HD BSPC                               &lts SPFN_HD ENTER      &space_tui 0 0
 				&kp LALT               &kp DEL                                         &tog NUM_HD_ULTRA       &kp LWIN
 				&sl FUNC                &kp C_AL_CALC                                   &kp C_AC_REFRESH        &sl FUNC
 			>;

--- a/docs/term-layout.md
+++ b/docs/term-layout.md
@@ -151,7 +151,7 @@ Use **`ldw`** for the suffix. Example **`thing`**: type labels for `t` `h` `i` `
 | E | `&ak_E` |
 | W | `&ak_W` |
 | left thumb | `&hmss SPACE GRAVE` (unchanged) |
-| right thumb | `&space_tui` → `&ak_SPACE` |
+| right thumb | `&space_tui 0 0` → `&ak_SPACE` |
 
 ## `ak_SPACE` (right thumb)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI build error from PR #37: hold-tap behaviors require `#binding-cells = <2>`.

## Fix

- `space_tui`: `#binding-cells = <0>` → `<2>`
- Keymap: `&space_tui` → `&space_tui 0 0` (dummy params for `&none` / `&ak_SPACE`)

## Test plan

- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf61c8-77ca-44dd-95a0-adb941d7b314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

